### PR TITLE
make raw-skt don't read more than rx_buffer_size

### DIFF
--- a/lib/roles/raw-skt/ops-raw-skt.c
+++ b/lib/roles/raw-skt/ops-raw-skt.c
@@ -172,7 +172,7 @@ rops_handle_POLLIN_raw_skt(struct lws_context_per_thread *pt, struct lws *wsi,
 #endif
 		default:
 			ebuf.token = NULL;
-			ebuf.len = 0;
+			ebuf.len = (int) wsi->a.protocol->rx_buffer_size;
 
 			buffered = lws_buflist_aware_read(pt, wsi, &ebuf, 1, __func__);
 			switch (ebuf.len) {


### PR DESCRIPTION
When other roles like ws reading data, they follow `rx_buffer_size`, then fallback to context's `pt_serv_buf_size`. However, `raw-skt` don't follow `rx_buffer_size`, always use 0, then fallback to `pt_serv_buf_size`.

This PR make `raw-skt` don't read more than `rx_buffer_size` data.

If there is other way to specify `raw-skt`'s maxmium data, please let me know.